### PR TITLE
[view] 항목 목록: UI 구현

### DIFF
--- a/BeepBeep.xcodeproj/project.pbxproj
+++ b/BeepBeep.xcodeproj/project.pbxproj
@@ -11,10 +11,11 @@
 		84BE59AF918F93AD7210BC28 /* Pods_BeepBeep_BeepBeepUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01D362CC3DD84D29946DF53D /* Pods_BeepBeep_BeepBeepUITests.framework */; };
 		8707BF6D26523C89004B082E /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8707BF6C26523C89004B082E /* RealmManager.swift */; };
 		8707BF7226526CD3004B082E /* CreateCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8707BF7126526CD3004B082E /* CreateCategoryViewModel.swift */; };
+		873827EA26622048008684D8 /* ListOfItemsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873827E926622048008684D8 /* ListOfItemsViewController.swift */; };
 		87531C8826457016009644EE /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 87531C8726457016009644EE /* .swiftlint.yml */; };
 		8793FDFC26441F8600F8578C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793FDFB26441F8600F8578C /* AppDelegate.swift */; };
 		8793FDFE26441F8600F8578C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793FDFD26441F8600F8578C /* SceneDelegate.swift */; };
-		8793FE0026441F8600F8578C /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793FDFF26441F8600F8578C /* ViewController.swift */; };
+		8793FE0026441F8600F8578C /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793FDFF26441F8600F8578C /* MainViewController.swift */; };
 		8793FE0826441F8800F8578C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8793FE0726441F8800F8578C /* Assets.xcassets */; };
 		8793FE0B26441F8800F8578C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8793FE0926441F8800F8578C /* LaunchScreen.storyboard */; };
 		8793FE1626441F8800F8578C /* BeepBeepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793FE1526441F8800F8578C /* BeepBeepTests.swift */; };
@@ -52,11 +53,12 @@
 		73145F053A01F519BB9FB5D4 /* Pods_BeepBeepTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BeepBeepTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8707BF6C26523C89004B082E /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
 		8707BF7126526CD3004B082E /* CreateCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCategoryViewModel.swift; sourceTree = "<group>"; };
+		873827E926622048008684D8 /* ListOfItemsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListOfItemsViewController.swift; sourceTree = "<group>"; };
 		87531C8726457016009644EE /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		8793FDF826441F8600F8578C /* BeepBeep.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BeepBeep.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8793FDFB26441F8600F8578C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8793FDFD26441F8600F8578C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		8793FDFF26441F8600F8578C /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		8793FDFF26441F8600F8578C /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		8793FE0726441F8800F8578C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8793FE0A26441F8800F8578C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8793FE0C26441F8800F8578C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -149,8 +151,9 @@
 		87531C8A26457384009644EE /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
-				8793FDFF26441F8600F8578C /* ViewController.swift */,
+				8793FDFF26441F8600F8578C /* MainViewController.swift */,
 				87DCC2CB264EA24F008FE490 /* CreateCategoryViewController.swift */,
+				873827E926622048008684D8 /* ListOfItemsViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -498,13 +501,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				87DCC2B3264D6BFF008FE490 /* Item.swift in Sources */,
-				8793FE0026441F8600F8578C /* ViewController.swift in Sources */,
+				8793FE0026441F8600F8578C /* MainViewController.swift in Sources */,
 				8707BF7226526CD3004B082E /* CreateCategoryViewModel.swift in Sources */,
 				8707BF6D26523C89004B082E /* RealmManager.swift in Sources */,
 				87DCC2B5264D6C06008FE490 /* Record.swift in Sources */,
 				8793FDFC26441F8600F8578C /* AppDelegate.swift in Sources */,
 				8793FDFE26441F8600F8578C /* SceneDelegate.swift in Sources */,
 				87DCC2B1264D69D4008FE490 /* Category.swift in Sources */,
+				873827EA26622048008684D8 /* ListOfItemsViewController.swift in Sources */,
 				87DCC2CC264EA24F008FE490 /* CreateCategoryViewController.swift in Sources */,
 				87C3C2C52646E27C007E7B8E /* RoundView.swift in Sources */,
 				87E87B262649414D007412F9 /* CollectionsCell.swift in Sources */,

--- a/BeepBeep/SceneDelegate.swift
+++ b/BeepBeep/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        window?.rootViewController = UINavigationController(rootViewController: ViewController())
+        window?.rootViewController = UINavigationController(rootViewController: MainViewController())
         window?.makeKeyAndVisible()
     }
 

--- a/BeepBeep/ViewController/ListOfItemsViewController.swift
+++ b/BeepBeep/ViewController/ListOfItemsViewController.swift
@@ -6,12 +6,74 @@
 //
 
 import UIKit
+import SnapKit
+import Then
 
 class ListOfItemsViewController: UIViewController {
+
+    // MARK: - View Properties
+
+    private let tableView = UITableView().then {
+        $0.separatorStyle = .none
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         view.backgroundColor = .systemBackground
+
+        configureNavigation()
+        configureViews()
+        setTableView()
+        setTableViewConstraints()
     }
+}
+
+// MARK: - Private
+private extension ListOfItemsViewController {
+    func configureNavigation() {
+        navigationController?.navigationBar.prefersLargeTitles = true
+
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: nil)
+    }
+
+    func configureViews() {
+        view.addSubview(tableView)
+    }
+
+    func setTableView() {
+        tableView.backgroundColor = .none
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+    }
+
+    func setTableViewConstraints() {
+        tableView.snp.makeConstraints {
+            $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(16)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(16)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-16)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
+        }
+    }
+}
+
+// MARK: - TableView Datasource
+extension ListOfItemsViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 10
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+
+        cell.textLabel?.text = "text"
+        cell.accessoryType = .disclosureIndicator
+
+        return cell
+    }
+}
+
+extension ListOfItemsViewController: UITableViewDelegate {
+
 }

--- a/BeepBeep/ViewController/ListOfItemsViewController.swift
+++ b/BeepBeep/ViewController/ListOfItemsViewController.swift
@@ -83,7 +83,7 @@ private extension ListOfItemsViewController {
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(16)
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(16)
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-16)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
+            $0.bottom.equalTo(practiceButton.snp.top).offset(-16)
         }
     }
 

--- a/BeepBeep/ViewController/ListOfItemsViewController.swift
+++ b/BeepBeep/ViewController/ListOfItemsViewController.swift
@@ -1,0 +1,17 @@
+//
+//  ListOfItemsViewController.swift
+//  BeepBeep
+//
+//  Created by 이지원 on 2021/05/29.
+//
+
+import UIKit
+
+class ListOfItemsViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemBackground
+    }
+}

--- a/BeepBeep/ViewController/ListOfItemsViewController.swift
+++ b/BeepBeep/ViewController/ListOfItemsViewController.swift
@@ -8,13 +8,34 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 class ListOfItemsViewController: UIViewController {
 
-    // MARK: - View Properties
+    // MARK: - Properties
+    private let disposeBag = DisposeBag()
 
+    // MARK: - View Properties
     private let tableView = UITableView().then {
         $0.separatorStyle = .none
+    }
+
+    private let practiceButton = UIButton().then {
+        $0.titleLabel?.adjustsFontForContentSizeCategory = true
+        $0.titleLabel?.numberOfLines = 1
+        $0.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+        $0.backgroundColor = .label
+        $0.setImage(UIImage(systemName: "mic"), for: .normal)
+        $0.tintColor = .systemBackground
+        $0.setTitle("연습하기", for: .normal)
+        $0.setTitleColor(.systemBackground, for: .normal)
+        $0.semanticContentAttribute = .forceLeftToRight
+        $0.contentVerticalAlignment = .center
+        $0.contentHorizontalAlignment = .center
+        $0.clipsToBounds = true
+        $0.titleEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: -8)
+        $0.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 24)
     }
 
     override func viewDidLoad() {
@@ -26,6 +47,13 @@ class ListOfItemsViewController: UIViewController {
         configureViews()
         setTableView()
         setTableViewConstraints()
+        setPracticeButtonConstraints()
+        bindInput()
+    }
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        practiceButton.layer.cornerRadius = practiceButton.frame.size.height / 2
     }
 }
 
@@ -39,6 +67,7 @@ private extension ListOfItemsViewController {
 
     func configureViews() {
         view.addSubview(tableView)
+        view.addSubview(practiceButton)
     }
 
     func setTableView() {
@@ -55,6 +84,23 @@ private extension ListOfItemsViewController {
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-16)
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
         }
+    }
+
+    func setPracticeButtonConstraints() {
+        practiceButton.snp.makeConstraints {
+            $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(32)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-32)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-16)
+        }
+    }
+
+    func bindInput() {
+        practiceButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .bind {
+                print("Tapped")
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/BeepBeep/ViewController/ListOfItemsViewController.swift
+++ b/BeepBeep/ViewController/ListOfItemsViewController.swift
@@ -49,6 +49,7 @@ class ListOfItemsViewController: UIViewController {
         setTableViewConstraints()
         setPracticeButtonConstraints()
         bindInput()
+        bindTableView()
     }
 
     override func viewWillLayoutSubviews() {
@@ -99,6 +100,15 @@ private extension ListOfItemsViewController {
             .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
             .bind {
                 print("Tapped")
+            }
+            .disposed(by: disposeBag)
+    }
+
+    func bindTableView() {
+        tableView.rx.itemSelected
+            .bind { [weak self] indexPath in
+                guard let self = self else { return }
+                self.tableView.deselectRow(at: indexPath, animated: true)
             }
             .disposed(by: disposeBag)
     }

--- a/BeepBeep/ViewController/MainViewController.swift
+++ b/BeepBeep/ViewController/MainViewController.swift
@@ -13,6 +13,9 @@ import RxCocoa
 
 class MainViewController: UIViewController {
 
+    // MARK: - Properties
+    private let disposeBag = DisposeBag()
+
     // MARK: - View Properties
     private let progressView = RoundView().then {
         $0.backgroundColor = UIColor(named: "BeepGray")
@@ -54,6 +57,7 @@ class MainViewController: UIViewController {
         setCategoryHeaderLabelConstraints()
         setCollectionViewConstraints()
         setNewCategoryButtonConstraints()
+        bindCollectionView()
     }
 
     override func viewWillLayoutSubviews() {
@@ -121,6 +125,17 @@ private extension MainViewController {
     @objc func createCategory() {
         self.navigationController?.pushViewController(CreateCategoryViewController(), animated: true)
     }
+
+    func bindCollectionView() {
+        collectionView.rx.itemSelected
+            .subscribe(onNext: { [weak self] indexPath in
+                guard let self = self else { return }
+                let listOfItemsViewController = ListOfItemsViewController()
+                listOfItemsViewController.title = "\(indexPath.row)번째"
+                self.navigationController?.pushViewController(listOfItemsViewController, animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
 }
 
 // MARK: - CollectionView Datasource
@@ -136,10 +151,6 @@ extension MainViewController: UICollectionViewDataSource {
         }
 
         return cell
-    }
-
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        self.navigationController?.pushViewController(ListOfItemsViewController(), animated: true)
     }
 }
 

--- a/BeepBeep/ViewController/MainViewController.swift
+++ b/BeepBeep/ViewController/MainViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
-class ViewController: UIViewController {
+class MainViewController: UIViewController {
 
     // MARK: - View Properties
     private let progressView = RoundView().then {
@@ -63,7 +63,7 @@ class ViewController: UIViewController {
 }
 
 // MARK: - Private
-private extension ViewController {
+private extension MainViewController {
     func configureNavigation() {
         self.title = "BeepBeep"
         navigationController?.navigationBar.prefersLargeTitles = true
@@ -124,7 +124,7 @@ private extension ViewController {
 }
 
 // MARK: - CollectionView Datasource
-extension ViewController: UICollectionViewDataSource {
+extension MainViewController: UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 10
@@ -140,7 +140,7 @@ extension ViewController: UICollectionViewDataSource {
 }
 
 // MARK: - CollectionView FlowLayout Delegate
-extension ViewController: UICollectionViewDelegateFlowLayout {
+extension MainViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: collectionView.frame.width, height: 72)
     }

--- a/BeepBeep/ViewController/MainViewController.swift
+++ b/BeepBeep/ViewController/MainViewController.swift
@@ -128,6 +128,7 @@ private extension MainViewController {
 
     func bindCollectionView() {
         collectionView.rx.itemSelected
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
             .subscribe(onNext: { [weak self] indexPath in
                 guard let self = self else { return }
                 let listOfItemsViewController = ListOfItemsViewController()

--- a/BeepBeep/ViewController/MainViewController.swift
+++ b/BeepBeep/ViewController/MainViewController.swift
@@ -129,12 +129,12 @@ private extension MainViewController {
     func bindCollectionView() {
         collectionView.rx.itemSelected
             .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] indexPath in
+            .bind { [weak self] indexPath in
                 guard let self = self else { return }
                 let listOfItemsViewController = ListOfItemsViewController()
                 listOfItemsViewController.title = "\(indexPath.row)번째"
                 self.navigationController?.pushViewController(listOfItemsViewController, animated: true)
-            })
+            }
             .disposed(by: disposeBag)
     }
 }

--- a/BeepBeep/ViewController/MainViewController.swift
+++ b/BeepBeep/ViewController/MainViewController.swift
@@ -137,6 +137,10 @@ extension MainViewController: UICollectionViewDataSource {
 
         return cell
     }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        self.navigationController?.pushViewController(ListOfItemsViewController(), animated: true)
+    }
 }
 
 // MARK: - CollectionView FlowLayout Delegate


### PR DESCRIPTION
## 개요

closed #4 closed #9 

항목 목록 UI 구현

## 작업사항

- 항목 목록을 테이블 뷰로 구현(기본 스타일 적용)
- 모음집 목록에서 항목 목록으로 이동
- 항목 목록 선택 시, deselect row 처리
- 연습하기 버튼 추가

## 스크린샷

<img src="https://user-images.githubusercontent.com/15073405/120325107-493d7180-c322-11eb-9bc0-6a2885b19f2b.png" width="50%"><img src="https://user-images.githubusercontent.com/15073405/120326032-3c6d4d80-c323-11eb-892f-b9d2383d85a8.png" width="50%">
<img src="https://user-images.githubusercontent.com/15073405/120325600-c832aa00-c322-11eb-9326-460016f1bb9c.png" width="50%"><img src="https://user-images.githubusercontent.com/15073405/120325630-d08ae500-c322-11eb-8ea1-c633e6f29f3d.png" width="50%">