### PR TITLE
[view] 항목 상세: UI 구현

### DIFF
--- a/BeepBeep.xcodeproj/project.pbxproj
+++ b/BeepBeep.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		87A2A7DD2667534A00AB1647 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 87A2A7DF2667534A00AB1647 /* Localizable.strings */; };
 		87A2A7E32667541300AB1647 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A2A7E22667541300AB1647 /* String+.swift */; };
 		87A2A7E62667589400AB1647 /* I18N.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A2A7E52667589400AB1647 /* I18N.swift */; };
+		87AA3D472674CD770046FDB8 /* ItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AA3D462674CD770046FDB8 /* ItemDetailViewController.swift */; };
 		87C3C2C52646E27C007E7B8E /* RoundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C3C2C42646E27C007E7B8E /* RoundView.swift */; };
 		87DCC2B1264D69D4008FE490 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DCC2B0264D69D4008FE490 /* Category.swift */; };
 		87DCC2B3264D6BFF008FE490 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DCC2B2264D6BFF008FE490 /* Item.swift */; };
@@ -76,6 +77,7 @@
 		87A2A7E12667537400AB1647 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		87A2A7E22667541300AB1647 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		87A2A7E52667589400AB1647 /* I18N.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18N.swift; sourceTree = "<group>"; };
+		87AA3D462674CD770046FDB8 /* ItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailViewController.swift; sourceTree = "<group>"; };
 		87C3C2C42646E27C007E7B8E /* RoundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundView.swift; sourceTree = "<group>"; };
 		87DCC2B0264D69D4008FE490 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		87DCC2B2264D6BFF008FE490 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 				8793FDFF26441F8600F8578C /* MainViewController.swift */,
 				87DCC2CB264EA24F008FE490 /* CreateCategoryViewController.swift */,
 				873827E926622048008684D8 /* ListOfItemsViewController.swift */,
+				87AA3D462674CD770046FDB8 /* ItemDetailViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -526,6 +529,7 @@
 				8793FE0026441F8600F8578C /* MainViewController.swift in Sources */,
 				8707BF7226526CD3004B082E /* CreateCategoryViewModel.swift in Sources */,
 				8707BF6D26523C89004B082E /* RealmManager.swift in Sources */,
+				87AA3D472674CD770046FDB8 /* ItemDetailViewController.swift in Sources */,
 				87DCC2B5264D6C06008FE490 /* Record.swift in Sources */,
 				8793FDFC26441F8600F8578C /* AppDelegate.swift in Sources */,
 				8793FDFE26441F8600F8578C /* SceneDelegate.swift in Sources */,

--- a/BeepBeep/Support Files/en.lproj/Localizable.strings
+++ b/BeepBeep/Support Files/en.lproj/Localizable.strings
@@ -13,3 +13,7 @@
 "newCollectionTitle" = "Create New Collection";
 "newCollectionNameFieldDescription" = "What is the Collection name?";
 "newCollectionNameFieldPlaceholder" = "Write the name of Collection here.";
+"modify" = "Modify";
+"delete" = "Delete";
+"cancle" = "Cancle";
+"selectOption"= "Select a Option";

--- a/BeepBeep/Support Files/ko.lproj/Localizable.strings
+++ b/BeepBeep/Support Files/ko.lproj/Localizable.strings
@@ -13,3 +13,7 @@
 "newCollectionTitle" = "새 모음집 만들기";
 "newCollectionNameFieldDescription" = "모음집 이름은 무엇인가요?";
 "newCollectionNameFieldPlaceholder" = "여기에 모음집 이름을 적어주세요.";
+"modify" = "수정";
+"delete" = "삭제";
+"cancle" = "취소";
+"selectOption" = "옵션 선택";

--- a/BeepBeep/Utilities/I18N.swift
+++ b/BeepBeep/Utilities/I18N.swift
@@ -15,4 +15,8 @@ struct I18N {
     static let newCollectionTitle = "newCollectionTitle".localized
     static let newCollectionNameFieldDescription = "newCollectionNameFieldDescription".localized
     static let newCollectionNameFieldPlaceholder = "newCollectionNameFieldPlaceholder".localized
+    static let modify = "modify".localized
+    static let delete = "delete".localized
+    static let cancle = "cancle".localized
+    static let actionsheetMessage = "selectOption".localized
 }

--- a/BeepBeep/ViewController/ItemDetailViewController.swift
+++ b/BeepBeep/ViewController/ItemDetailViewController.swift
@@ -13,5 +13,56 @@ class ItemDetailViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .systemBackground
+
+        configureNavigation()
+    }
+}
+
+// MARK: - Private
+private extension ItemDetailViewController {
+
+    var menuItems: [UIAction] {
+        return [
+            UIAction(title: I18N.modify, image: UIImage(systemName: "pencil"), handler: { _ in }),
+            UIAction(title: I18N.delete, image: UIImage(systemName: "trash"), attributes: .destructive, handler: { _ in })
+        ]
+    }
+
+    var menu: UIMenu {
+        return UIMenu(title: "", image: nil, identifier: nil, options: [], children: menuItems)
+    }
+
+    func configureNavigation() {
+        navigationController?.navigationBar.prefersLargeTitles = false
+
+        if #available(iOS 14.0, *) {
+            self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "",
+                                                                     image: UIImage(systemName: "ellipsis.circle"),
+                                                                     primaryAction: nil,
+                                                                     menu: menu)
+        } else {
+            self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"),
+                                                                     style: .plain,
+                                                                     target: self,
+                                                                     action: #selector(moreActionTapped))
+        }
+    }
+
+    @objc func moreActionTapped(_ sender: UIBarButtonItem) {
+        if #available(iOS 14.0, *) {
+
+        } else {
+            let alert = UIAlertController(title: nil, message: I18N.actionsheetMessage, preferredStyle: .actionSheet)
+
+            let deleteAction = UIAlertAction(title: I18N.modify, style: .default, handler: { _ in })
+            let saveAction = UIAlertAction(title: I18N.delete, style: .destructive, handler: { _ in })
+            let cancelAction = UIAlertAction(title: I18N.cancle, style: .cancel, handler: { _ in })
+
+            alert.addAction(deleteAction)
+            alert.addAction(saveAction)
+            alert.addAction(cancelAction)
+
+            self.present(alert, animated: true, completion: nil)
+        }
     }
 }

--- a/BeepBeep/ViewController/ItemDetailViewController.swift
+++ b/BeepBeep/ViewController/ItemDetailViewController.swift
@@ -38,7 +38,7 @@ class ItemDetailViewController: UIViewController {
         $0.textColor = .label
     }
 
-    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    private let tableView = UITableView(frame: .zero, style: .grouped)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -47,11 +47,11 @@ class ItemDetailViewController: UIViewController {
 
         configureNavigation()
         configureViews()
-        setCollectionView()
+        setTableView()
         setTitleLabelConstraints()
         setAnswerTextViewConstraints()
         setRecordTitleLabelConstraints()
-        setCollectionViewConstraints()
+        setTableViewConstraints()
     }
 }
 
@@ -107,13 +107,14 @@ private extension ItemDetailViewController {
         view.addSubview(titleLabel)
         view.addSubview(answerTextView)
         view.addSubview(recordTitleLabel)
-        view.addSubview(collectionView)
+        view.addSubview(tableView)
     }
 
-    func setCollectionView() {
-        collectionView.backgroundColor = .none
-        collectionView.register(CollectionsCell.self, forCellWithReuseIdentifier: CollectionsCell.identifier)
+    func setTableView() {
+        tableView.backgroundColor = .none
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
     }
+
     func setTitleLabelConstraints() {
         titleLabel.snp.makeConstraints {
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(32)
@@ -139,8 +140,8 @@ private extension ItemDetailViewController {
         }
     }
 
-    func setCollectionViewConstraints() {
-        collectionView.snp.makeConstraints {
+    func setTableViewConstraints() {
+        tableView.snp.makeConstraints {
             $0.leading.equalTo(titleLabel.snp.leading)
             $0.top.equalTo(recordTitleLabel.snp.bottom).offset(32)
             $0.trailing.equalTo(titleLabel.snp.trailing)

--- a/BeepBeep/ViewController/ItemDetailViewController.swift
+++ b/BeepBeep/ViewController/ItemDetailViewController.swift
@@ -1,0 +1,17 @@
+//
+//  ItemDetailViewController.swift
+//  BeepBeep
+//
+//  Created by 이지원 on 2021/06/12.
+//
+
+import UIKit
+
+class ItemDetailViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemBackground
+    }
+}

--- a/BeepBeep/ViewController/ItemDetailViewController.swift
+++ b/BeepBeep/ViewController/ItemDetailViewController.swift
@@ -6,8 +6,39 @@
 //
 
 import UIKit
+import SnapKit
+import Then
+import RxSwift
+import RxCocoa
 
 class ItemDetailViewController: UIViewController {
+
+    // MARK: - Properties
+    let disposeBag = DisposeBag()
+
+    // MARK: - View Properties
+    private let titleLabel = UILabel().then {
+        $0.font = UIFont.preferredFont(forTextStyle: .largeTitle)
+        $0.text = "What is your favorite?"
+        $0.textColor = .label
+    }
+
+    private let answerTextView = UITextView().then {
+        $0.font = UIFont.preferredFont(forTextStyle: .body)
+        $0.isEditable = false
+        $0.backgroundColor = UIColor(named: "BeepGray")
+        $0.textColor = .label
+        $0.layer.cornerRadius = 15
+        $0.clipsToBounds = true
+    }
+
+    private let recordTitleLabel = UILabel().then {
+        $0.font = UIFont.preferredFont(forTextStyle: .largeTitle)
+        $0.text = "Detail Blah"
+        $0.textColor = .label
+    }
+
+    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -15,6 +46,12 @@ class ItemDetailViewController: UIViewController {
         view.backgroundColor = .systemBackground
 
         configureNavigation()
+        configureViews()
+        setCollectionView()
+        setTitleLabelConstraints()
+        setAnswerTextViewConstraints()
+        setRecordTitleLabelConstraints()
+        setCollectionViewConstraints()
     }
 }
 
@@ -63,6 +100,51 @@ private extension ItemDetailViewController {
             alert.addAction(cancelAction)
 
             self.present(alert, animated: true, completion: nil)
+        }
+    }
+
+    func configureViews() {
+        view.addSubview(titleLabel)
+        view.addSubview(answerTextView)
+        view.addSubview(recordTitleLabel)
+        view.addSubview(collectionView)
+    }
+
+    func setCollectionView() {
+        collectionView.backgroundColor = .none
+        collectionView.register(CollectionsCell.self, forCellWithReuseIdentifier: CollectionsCell.identifier)
+    }
+    func setTitleLabelConstraints() {
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).offset(32)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(32)
+            $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).offset(-32)
+        }
+    }
+
+    func setAnswerTextViewConstraints() {
+        answerTextView.snp.makeConstraints {
+            $0.leading.equalTo(titleLabel.snp.leading)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(32)
+            $0.trailing.equalTo(titleLabel.snp.trailing)
+            $0.height.equalTo(view.safeAreaLayoutGuide.snp.height).multipliedBy(0.3)
+        }
+    }
+
+    func setRecordTitleLabelConstraints() {
+        recordTitleLabel.snp.makeConstraints {
+            $0.leading.equalTo(titleLabel.snp.leading)
+            $0.top.equalTo(answerTextView.snp.bottom).offset(32)
+            $0.trailing.equalTo(titleLabel.snp.trailing)
+        }
+    }
+
+    func setCollectionViewConstraints() {
+        collectionView.snp.makeConstraints {
+            $0.leading.equalTo(titleLabel.snp.leading)
+            $0.top.equalTo(recordTitleLabel.snp.bottom).offset(32)
+            $0.trailing.equalTo(titleLabel.snp.trailing)
+            $0.bottom.equalToSuperview().offset(-32)
         }
     }
 }

--- a/BeepBeep/ViewController/ListOfItemsViewController.swift
+++ b/BeepBeep/ViewController/ListOfItemsViewController.swift
@@ -109,6 +109,9 @@ private extension ListOfItemsViewController {
             .bind { [weak self] indexPath in
                 guard let self = self else { return }
                 self.tableView.deselectRow(at: indexPath, animated: true)
+                let itemDetailViewController = ItemDetailViewController()
+                itemDetailViewController.title = "\(indexPath.row)"
+                self.navigationController?.pushViewController(itemDetailViewController, animated: true)
             }
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 개요

closed #6 #10 

항목 상세 UI 구현

## 작업사항

- 네비게이션 우측 버튼 작업
  - iOS 14.0 ↑: UIMenu
  - iOS 14.0 ↓: UIAlertController(.actionsheet)
- 녹음 목록을 테이블뷰로 구성

## 스크린샷

<img src="https://user-images.githubusercontent.com/15073405/121808389-323c3f00-cc93-11eb-960e-dd0ff93771e8.png" width="50%"><img src="https://user-images.githubusercontent.com/15073405/121808382-25b7e680-cc93-11eb-9ab9-4ba744666180.png" width="50%">

## 비고

- 녹음 기능(화면)을 Bottom Sheet 형태로 구현할 예정 (like iOS Voice Recorder App)