### PR TITLE
[view] 녹음 화면: UI 구현

### DIFF
--- a/BeepBeep.xcodeproj/project.pbxproj
+++ b/BeepBeep.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		87A2A7E32667541300AB1647 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A2A7E22667541300AB1647 /* String+.swift */; };
 		87A2A7E62667589400AB1647 /* I18N.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A2A7E52667589400AB1647 /* I18N.swift */; };
 		87AA3D472674CD770046FDB8 /* ItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AA3D462674CD770046FDB8 /* ItemDetailViewController.swift */; };
+		87AA3D4926763FE80046FDB8 /* RecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AA3D4826763FE80046FDB8 /* RecordViewController.swift */; };
 		87C3C2C52646E27C007E7B8E /* RoundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C3C2C42646E27C007E7B8E /* RoundView.swift */; };
 		87DCC2B1264D69D4008FE490 /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DCC2B0264D69D4008FE490 /* Category.swift */; };
 		87DCC2B3264D6BFF008FE490 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DCC2B2264D6BFF008FE490 /* Item.swift */; };
@@ -78,6 +79,7 @@
 		87A2A7E22667541300AB1647 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		87A2A7E52667589400AB1647 /* I18N.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18N.swift; sourceTree = "<group>"; };
 		87AA3D462674CD770046FDB8 /* ItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailViewController.swift; sourceTree = "<group>"; };
+		87AA3D4826763FE80046FDB8 /* RecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewController.swift; sourceTree = "<group>"; };
 		87C3C2C42646E27C007E7B8E /* RoundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundView.swift; sourceTree = "<group>"; };
 		87DCC2B0264D69D4008FE490 /* Category.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		87DCC2B2264D6BFF008FE490 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
@@ -165,6 +167,7 @@
 				87DCC2CB264EA24F008FE490 /* CreateCategoryViewController.swift */,
 				873827E926622048008684D8 /* ListOfItemsViewController.swift */,
 				87AA3D462674CD770046FDB8 /* ItemDetailViewController.swift */,
+				87AA3D4826763FE80046FDB8 /* RecordViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -527,6 +530,7 @@
 				87DCC2B3264D6BFF008FE490 /* Item.swift in Sources */,
 				87A2A7E62667589400AB1647 /* I18N.swift in Sources */,
 				8793FE0026441F8600F8578C /* MainViewController.swift in Sources */,
+				87AA3D4926763FE80046FDB8 /* RecordViewController.swift in Sources */,
 				8707BF7226526CD3004B082E /* CreateCategoryViewModel.swift in Sources */,
 				8707BF6D26523C89004B082E /* RealmManager.swift in Sources */,
 				87AA3D472674CD770046FDB8 /* ItemDetailViewController.swift in Sources */,

--- a/BeepBeep.xcodeproj/project.pbxproj
+++ b/BeepBeep.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		8707BF6D26523C89004B082E /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8707BF6C26523C89004B082E /* RealmManager.swift */; };
 		8707BF7226526CD3004B082E /* CreateCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8707BF7126526CD3004B082E /* CreateCategoryViewModel.swift */; };
 		8718832C2678A6E500830492 /* RecordButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718832B2678A6E500830492 /* RecordButton.swift */; };
+		871DDDFD2680984900851FDD /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871DDDFC2680984900851FDD /* RecordViewModel.swift */; };
 		873827EA26622048008684D8 /* ListOfItemsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873827E926622048008684D8 /* ListOfItemsViewController.swift */; };
 		87531C8826457016009644EE /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 87531C8726457016009644EE /* .swiftlint.yml */; };
 		8793FDFC26441F8600F8578C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793FDFB26441F8600F8578C /* AppDelegate.swift */; };
@@ -60,6 +61,7 @@
 		8707BF6C26523C89004B082E /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
 		8707BF7126526CD3004B082E /* CreateCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCategoryViewModel.swift; sourceTree = "<group>"; };
 		8718832B2678A6E500830492 /* RecordButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordButton.swift; sourceTree = "<group>"; };
+		871DDDFC2680984900851FDD /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
 		873827E926622048008684D8 /* ListOfItemsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListOfItemsViewController.swift; sourceTree = "<group>"; };
 		87531C8726457016009644EE /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		8793FDF826441F8600F8578C /* BeepBeep.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BeepBeep.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -150,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				8707BF7126526CD3004B082E /* CreateCategoryViewModel.swift */,
+				871DDDFC2680984900851FDD /* RecordViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -541,6 +544,7 @@
 				8793FDFC26441F8600F8578C /* AppDelegate.swift in Sources */,
 				8793FDFE26441F8600F8578C /* SceneDelegate.swift in Sources */,
 				87DCC2B1264D69D4008FE490 /* Category.swift in Sources */,
+				871DDDFD2680984900851FDD /* RecordViewModel.swift in Sources */,
 				8718832C2678A6E500830492 /* RecordButton.swift in Sources */,
 				873827EA26622048008684D8 /* ListOfItemsViewController.swift in Sources */,
 				87DCC2CC264EA24F008FE490 /* CreateCategoryViewController.swift in Sources */,

--- a/BeepBeep.xcodeproj/project.pbxproj
+++ b/BeepBeep.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		84BE59AF918F93AD7210BC28 /* Pods_BeepBeep_BeepBeepUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01D362CC3DD84D29946DF53D /* Pods_BeepBeep_BeepBeepUITests.framework */; };
 		8707BF6D26523C89004B082E /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8707BF6C26523C89004B082E /* RealmManager.swift */; };
 		8707BF7226526CD3004B082E /* CreateCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8707BF7126526CD3004B082E /* CreateCategoryViewModel.swift */; };
+		8718832C2678A6E500830492 /* RecordButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8718832B2678A6E500830492 /* RecordButton.swift */; };
 		873827EA26622048008684D8 /* ListOfItemsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 873827E926622048008684D8 /* ListOfItemsViewController.swift */; };
 		87531C8826457016009644EE /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 87531C8726457016009644EE /* .swiftlint.yml */; };
 		8793FDFC26441F8600F8578C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8793FDFB26441F8600F8578C /* AppDelegate.swift */; };
@@ -58,6 +59,7 @@
 		73145F053A01F519BB9FB5D4 /* Pods_BeepBeepTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BeepBeepTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8707BF6C26523C89004B082E /* RealmManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmManager.swift; sourceTree = "<group>"; };
 		8707BF7126526CD3004B082E /* CreateCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCategoryViewModel.swift; sourceTree = "<group>"; };
+		8718832B2678A6E500830492 /* RecordButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordButton.swift; sourceTree = "<group>"; };
 		873827E926622048008684D8 /* ListOfItemsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListOfItemsViewController.swift; sourceTree = "<group>"; };
 		87531C8726457016009644EE /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		8793FDF826441F8600F8578C /* BeepBeep.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BeepBeep.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -186,6 +188,7 @@
 			children = (
 				87C3C2C42646E27C007E7B8E /* RoundView.swift */,
 				87E87B252649414C007412F9 /* CollectionsCell.swift */,
+				8718832B2678A6E500830492 /* RecordButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -538,6 +541,7 @@
 				8793FDFC26441F8600F8578C /* AppDelegate.swift in Sources */,
 				8793FDFE26441F8600F8578C /* SceneDelegate.swift in Sources */,
 				87DCC2B1264D69D4008FE490 /* Category.swift in Sources */,
+				8718832C2678A6E500830492 /* RecordButton.swift in Sources */,
 				873827EA26622048008684D8 /* ListOfItemsViewController.swift in Sources */,
 				87DCC2CC264EA24F008FE490 /* CreateCategoryViewController.swift in Sources */,
 				87A2A7E32667541300AB1647 /* String+.swift in Sources */,

--- a/BeepBeep.xcodeproj/xcshareddata/xcschemes/BeepBeep.xcscheme
+++ b/BeepBeep.xcodeproj/xcshareddata/xcschemes/BeepBeep.xcscheme
@@ -31,9 +31,9 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/BeepBeep.xcodeproj/xcshareddata/xcschemes/BeepBeep.xcscheme
+++ b/BeepBeep.xcodeproj/xcshareddata/xcschemes/BeepBeep.xcscheme
@@ -31,9 +31,9 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/BeepBeep.xcodeproj/xcshareddata/xcschemes/BeepBeep.xcscheme
+++ b/BeepBeep.xcodeproj/xcshareddata/xcschemes/BeepBeep.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8793FDF726441F8600F8578C"
+               BuildableName = "BeepBeep.app"
+               BlueprintName = "BeepBeep"
+               ReferencedContainer = "container:BeepBeep.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8793FDF726441F8600F8578C"
+            BuildableName = "BeepBeep.app"
+            BlueprintName = "BeepBeep"
+            ReferencedContainer = "container:BeepBeep.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8793FDF726441F8600F8578C"
+            BuildableName = "BeepBeep.app"
+            BlueprintName = "BeepBeep"
+            ReferencedContainer = "container:BeepBeep.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BeepBeep/View/RecordButton.swift
+++ b/BeepBeep/View/RecordButton.swift
@@ -1,0 +1,93 @@
+//
+//  RecordButton.swift
+//  BeepBeep
+//
+//  Created by 이지원 on 2021/06/15.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+import Then
+
+class RecordButton: UIButton {
+
+    private let animationDuration = 0.4
+    private var isRecording: Bool = false
+    private var circleSize: Int = 50
+    private var squareSize: Int {
+        get {
+            return Int(Double(circleSize) * 0.7)
+        }
+    }
+    private let disposeBag = DisposeBag()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        configure()
+        self.rx.tap
+            .bind { self.tapped() }
+            .disposed(by: disposeBag)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+
+        configure()
+        self.rx.tap
+            .bind { self.tapped() }
+            .disposed(by: disposeBag)
+    }
+
+    init(_ circleSize: Int) {
+        super.init(frame: .zero)
+
+        self.circleSize = circleSize
+
+        configure()
+        self.rx.tap
+            .bind { self.tapped() }
+            .disposed(by: disposeBag)
+    }
+
+}
+
+private extension RecordButton {
+    func configure() {
+        self.snp.makeConstraints {
+            $0.width.equalTo(self.circleSize)
+            $0.height.equalTo(self.circleSize)
+        }
+
+        self.setTitle("", for: .normal)
+        self.backgroundColor = .systemRed
+        self.layer.cornerRadius = CGFloat(circleSize) / 2
+    }
+
+    func tapped() {
+        if isRecording {
+            UIView.animate(withDuration: animationDuration) {
+                self.snp.updateConstraints {
+                    $0.width.equalTo(self.circleSize)
+                    $0.height.equalTo(self.circleSize)
+                }
+                self.layoutIfNeeded()
+
+                self.layer.cornerRadius = self.frame.height / 2
+            }
+        } else {
+            UIView.animate(withDuration: animationDuration) {
+                self.snp.updateConstraints {
+                    $0.width.equalTo(self.squareSize)
+                    $0.height.equalTo(self.squareSize)
+                }
+                self.layoutIfNeeded()
+                self.layer.cornerRadius = 0
+            }
+        }
+
+        isRecording = !isRecording
+    }
+}

--- a/BeepBeep/ViewController/ItemDetailViewController.swift
+++ b/BeepBeep/ViewController/ItemDetailViewController.swift
@@ -185,16 +185,6 @@ extension ItemDetailViewController: FloatingPanelControllerDelegate {
             fpc.surfaceView.grabberHandle.isHidden = false
         }
     }
-
-    func floatingPanelDidMove(_ fpc: FloatingPanelController) {
-        if fpc.isAttracting == false {
-            let loc = fpc.surfaceLocation
-            let minY = fpc.surfaceLocation(for: .full).y - 6.0
-            let maxY = fpc.surfaceLocation(for: .half).y
-            fpc.surfaceLocation = CGPoint(x: loc.x, y: min(max(loc.y, minY), maxY))
-        }
-
-    }
 }
 
 class RecordFloatingPanelLayout: FloatingPanelLayout {

--- a/BeepBeep/ViewController/ItemDetailViewController.swift
+++ b/BeepBeep/ViewController/ItemDetailViewController.swift
@@ -169,10 +169,6 @@ private extension ItemDetailViewController {
             $0.bottom.equalToSuperview().offset(-32)
         }
     }
-
-    func test() {
-        floatingPanelController.move(to: .half, animated: true)
-    }
 }
 
 extension ItemDetailViewController: FloatingPanelControllerDelegate {

--- a/BeepBeep/ViewController/ItemDetailViewController.swift
+++ b/BeepBeep/ViewController/ItemDetailViewController.swift
@@ -123,6 +123,7 @@ private extension ItemDetailViewController {
         floatingPanelController.view.frame = self.view.bounds
         floatingPanelController.delegate = self
         floatingPanelController.layout = RecordFloatingPanelLayout()
+        floatingPanelController.contentMode = .fitToBounds
 
         let appearance = SurfaceAppearance()
         appearance.cornerRadius = 20.0

--- a/BeepBeep/ViewController/ItemDetailViewController.swift
+++ b/BeepBeep/ViewController/ItemDetailViewController.swift
@@ -181,6 +181,7 @@ extension ItemDetailViewController: FloatingPanelControllerDelegate {
         switch fpc.state {
         case .tip:
             fpc.surfaceView.grabberHandle.isHidden = true
+            // TODO: 핸들바를 이용해 강제로 fpc를 .tip으로 줄였으면, 녹음 버튼을 종료 상태로 변경한다.
         default:
             fpc.surfaceView.grabberHandle.isHidden = false
         }

--- a/BeepBeep/ViewController/RecordViewController.swift
+++ b/BeepBeep/ViewController/RecordViewController.swift
@@ -80,10 +80,18 @@ private extension RecordViewController {
     }
 
     func moveToHalf() {
-        (self.parent as! FloatingPanelController).move(to: .half, animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            UIView.animate(withDuration: TimeInterval(0.3)) {
+                (self.parent as! FloatingPanelController).move(to: .half, animated: false)
+            }
+        }
     }
 
     func moveToTip() {
-        (self.parent as! FloatingPanelController).move(to: .tip, animated: true)
+        DispatchQueue.main.async {
+            UIView.animate(withDuration: TimeInterval(0.3)) {
+                (self.parent as! FloatingPanelController).move(to: .tip, animated: false)
+            }
+        }
     }
 }

--- a/BeepBeep/ViewController/RecordViewController.swift
+++ b/BeepBeep/ViewController/RecordViewController.swift
@@ -13,10 +13,11 @@ import RxCocoa
 import FloatingPanel
 
 class RecordViewController: UIViewController {
-
+    
     // MARK: - Properties
     private let disposeBag = DisposeBag()
-
+    private let viewModel = RecordViewModel()
+    
     // MARK: - View Properties
     let recordView = UIView().then {
         $0.layer.cornerRadius = 33
@@ -24,12 +25,12 @@ class RecordViewController: UIViewController {
         $0.layer.borderColor = UIColor.secondaryLabel.cgColor
         $0.layer.masksToBounds = true
     }
-
+    
     let recordButton = RecordButton()
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         view.backgroundColor = .systemBackground
         configureViews()
         setRecordViewConstraints()
@@ -43,7 +44,7 @@ private extension RecordViewController {
         recordView.addSubview(recordButton)
         view.addSubview(recordView)
     }
-
+    
     func setRecordViewConstraints() {
         recordView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
@@ -52,21 +53,36 @@ private extension RecordViewController {
             $0.height.equalTo(recordView.snp.width)
         }
     }
-
+    
     func setRecordButtonConstraints() {
         recordButton.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
     }
-
+    
     func bindInput() {
         recordButton.rx.tap
-            .delay(.milliseconds(5), scheduler: MainScheduler.instance)
-            .bind { self.moveToHalf() }
+            .bind { self.viewModel.recording() }
             .disposed(by: disposeBag)
     }
-
+    
+    func bindOutput() {
+        viewModel.isRecordingRelay
+            .subscribe(onNext: { isRecording in
+                if isRecording {
+                    self.moveToHalf()
+                } else {
+                    self.moveToTip()
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
     func moveToHalf() {
         (self.parent as! FloatingPanelController).move(to: .half, animated: true)
+    }
+    
+    func moveToTip() {
+        (self.parent as! FloatingPanelController).move(to: .tip, animated: true)
     }
 }

--- a/BeepBeep/ViewController/RecordViewController.swift
+++ b/BeepBeep/ViewController/RecordViewController.swift
@@ -9,9 +9,27 @@ import UIKit
 
 class RecordViewController: UIViewController {
 
+    // MARK: - View Properties
+    let recordButton = RecordButton()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         view.backgroundColor = .systemBackground
+        configureViews()
+        setRecordButtonConstraints()
+    }
+}
+
+private extension RecordViewController {
+    func configureViews() {
+        view.addSubview(recordButton)
+    }
+
+    func setRecordButtonConstraints() {
+        recordButton.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
     }
 }

--- a/BeepBeep/ViewController/RecordViewController.swift
+++ b/BeepBeep/ViewController/RecordViewController.swift
@@ -13,11 +13,11 @@ import RxCocoa
 import FloatingPanel
 
 class RecordViewController: UIViewController {
-    
+
     // MARK: - Properties
     private let disposeBag = DisposeBag()
     private let viewModel = RecordViewModel()
-    
+
     // MARK: - View Properties
     let recordView = UIView().then {
         $0.layer.cornerRadius = 33
@@ -25,12 +25,12 @@ class RecordViewController: UIViewController {
         $0.layer.borderColor = UIColor.secondaryLabel.cgColor
         $0.layer.masksToBounds = true
     }
-    
+
     let recordButton = RecordButton()
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         view.backgroundColor = .systemBackground
         configureViews()
         setRecordViewConstraints()
@@ -44,7 +44,7 @@ private extension RecordViewController {
         recordView.addSubview(recordButton)
         view.addSubview(recordView)
     }
-    
+
     func setRecordViewConstraints() {
         recordView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
@@ -53,19 +53,19 @@ private extension RecordViewController {
             $0.height.equalTo(recordView.snp.width)
         }
     }
-    
+
     func setRecordButtonConstraints() {
         recordButton.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
     }
-    
+
     func bindInput() {
         recordButton.rx.tap
             .bind { self.viewModel.recording() }
             .disposed(by: disposeBag)
     }
-    
+
     func bindOutput() {
         viewModel.isRecordingRelay
             .subscribe(onNext: { isRecording in
@@ -77,11 +77,11 @@ private extension RecordViewController {
             })
             .disposed(by: disposeBag)
     }
-    
+
     func moveToHalf() {
         (self.parent as! FloatingPanelController).move(to: .half, animated: true)
     }
-    
+
     func moveToTip() {
         (self.parent as! FloatingPanelController).move(to: .tip, animated: true)
     }

--- a/BeepBeep/ViewController/RecordViewController.swift
+++ b/BeepBeep/ViewController/RecordViewController.swift
@@ -36,6 +36,7 @@ class RecordViewController: UIViewController {
         setRecordViewConstraints()
         setRecordButtonConstraints()
         bindInput()
+        bindOutput()
     }
 }
 

--- a/BeepBeep/ViewController/RecordViewController.swift
+++ b/BeepBeep/ViewController/RecordViewController.swift
@@ -6,10 +6,25 @@
 //
 
 import UIKit
+import SnapKit
+import Then
+import RxSwift
+import RxCocoa
+import FloatingPanel
 
 class RecordViewController: UIViewController {
 
+    // MARK: - Properties
+    private let disposeBag = DisposeBag()
+
     // MARK: - View Properties
+    let recordView = UIView().then {
+        $0.layer.cornerRadius = 33
+        $0.layer.borderWidth = 3
+        $0.layer.borderColor = UIColor.secondaryLabel.cgColor
+        $0.layer.masksToBounds = true
+    }
+
     let recordButton = RecordButton()
 
     override func viewDidLoad() {
@@ -17,19 +32,41 @@ class RecordViewController: UIViewController {
 
         view.backgroundColor = .systemBackground
         configureViews()
+        setRecordViewConstraints()
         setRecordButtonConstraints()
+        bindInput()
     }
 }
 
 private extension RecordViewController {
     func configureViews() {
-        view.addSubview(recordButton)
+        recordView.addSubview(recordButton)
+        view.addSubview(recordView)
+    }
+
+    func setRecordViewConstraints() {
+        recordView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().offset(-32)
+            $0.width.equalTo(66)
+            $0.height.equalTo(recordView.snp.width)
+        }
     }
 
     func setRecordButtonConstraints() {
         recordButton.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.centerY.equalToSuperview()
+            $0.center.equalToSuperview()
         }
+    }
+
+    func bindInput() {
+        recordButton.rx.tap
+            .delay(.milliseconds(5), scheduler: MainScheduler.instance)
+            .bind { self.moveToHalf() }
+            .disposed(by: disposeBag)
+    }
+
+    func moveToHalf() {
+        (self.parent as! FloatingPanelController).move(to: .half, animated: true)
     }
 }

--- a/BeepBeep/ViewController/RecordViewController.swift
+++ b/BeepBeep/ViewController/RecordViewController.swift
@@ -1,0 +1,17 @@
+//
+//  RecordViewController.swift
+//  BeepBeep
+//
+//  Created by 이지원 on 2021/06/13.
+//
+
+import UIKit
+
+class RecordViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemBackground
+    }
+}

--- a/BeepBeep/ViewModel/RecordViewModel.swift
+++ b/BeepBeep/ViewModel/RecordViewModel.swift
@@ -1,0 +1,25 @@
+//
+//  RecordViewModel.swift
+//  BeepBeep
+//
+//  Created by 이지원 on 2021/06/21.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+class RecordViewModel {
+    private let disposeBag = DisposeBag()
+    private var isRecording = false {
+        didSet {
+            isRecordingRelay.accept(isRecording)
+        }
+    }
+    let isRecordingRelay = PublishRelay<Bool>()
+
+    func recording() {
+        isRecording = !isRecording
+    }
+}

--- a/Podfile
+++ b/Podfile
@@ -13,6 +13,7 @@ target 'BeepBeep' do
   pod 'Then'
   pod 'RealmSwift'
   pod 'ISEmojiView'
+  pod 'FloatingPanel'
 
   target 'BeepBeepTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,4 +1,5 @@
 PODS:
+  - FloatingPanel (2.4.0)
   - ISEmojiView (0.2.6)
   - Realm (10.7.5):
     - Realm/Headers (= 10.7.5)
@@ -16,6 +17,7 @@ PODS:
   - Then (2.7.0)
 
 DEPENDENCIES:
+  - FloatingPanel
   - ISEmojiView
   - RealmSwift
   - RxCocoa (= 6.1.0)
@@ -26,6 +28,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - FloatingPanel
     - ISEmojiView
     - Realm
     - RealmSwift
@@ -37,6 +40,7 @@ SPEC REPOS:
     - Then
 
 SPEC CHECKSUMS:
+  FloatingPanel: fa60183672ed86313b9e241e34465e82211260e8
   ISEmojiView: f7cd94a6c93307f429ec5da001293d0b02247f03
   Realm: 06f5c67f87cb8c5f27b122218ce22e9a77314517
   RealmSwift: b46535b52e69b9ed33912f0fcb3182ab0a5743ee
@@ -47,6 +51,6 @@ SPEC CHECKSUMS:
   SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
   Then: acfe0be7e98221c6204e12f8161459606d5d822d
 
-PODFILE CHECKSUM: d5f5046eceb27eaac9eab68251a08f1ac1636f34
+PODFILE CHECKSUM: d66ee7b68481fcc3a8081268ae18164ed83f1d98
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1


### PR DESCRIPTION
## 개요

closed #7

녹음 화면을 `ItemDetailViewController` 하단 `FloatingPanel`로 구현

## 작업사항

- `RecordButton`
- `RecordButton`을 탭하면 녹음 시작(플로팅 패널이 가운데 까지 올라옴). 다시 탭하면 녹음 종료(플로팅 패널이 하단으로 내려감)

## 스크린샷

<img src="https://user-images.githubusercontent.com/15073405/123275755-91297000-d53f-11eb-956c-bfd9a8efa61f.png" width="50%"><img src="https://user-images.githubusercontent.com/15073405/123275776-95558d80-d53f-11eb-8a00-c90947c73f67.png" width="50%">

## TODO

- 핸들바를 이용해 강제로 `fpc`를 `.tip`으로 줄였으면, 녹음 버튼을 종료 상태로 변경한다.
- 추가적인 UI 구현을 해야 하는데(오디오 녹음을 나타내는 애니메이션, 재생, 삭제 등) 이 부분을 계속 붙잡고 있으니 재미 없어서 진도가 안 나간다. 그래서 녹음 로직부터 구현하고 추가 구현할 예정이다.